### PR TITLE
Fix clean script path

### DIFF
--- a/.github/workflows/clean_validation_envs.yml
+++ b/.github/workflows/clean_validation_envs.yml
@@ -31,4 +31,4 @@ jobs:
           MAIN_TRE_ID: ${{ secrets.TRE_ID }}
           BRANCH_LAST_ACTIVITY_IN_HOURS_FOR_STOP: 2
           BRANCH_LAST_ACTIVITY_IN_HOURS_FOR_DESTROY: 48
-        run: devops/scripts/clean_ci_validation_envs.sh
+        run: .github/scripts/clean_ci_validation_envs.sh


### PR DESCRIPTION
## What is being addressed

The workflow that cleans old environments had a wrong path to a script. This resolves #13 