### PR TITLE
Markdown cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,18 @@ SHELL:=/bin/bash
 
 AZURETRE_HOME?="AzureTRE"
 
+# This must come before the include statement
+# Otherwise, $(lastword) will be the last included file
+THIS_MAKEFILE_FULLPATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+THIS_MAKEFILE_DIR := $(dir $(THIS_MAKEFILE_FULLPATH))
+
 include $(AZURETRE_HOME)/Makefile
 
 # Add your make commands down here
+
+# This is a sample make command to build user resource templates that are in this repo, versus the AzureTRE core repo
+# Any "make bundle" command from the AzureTRE core repo can be pasted here by modifying the command name
+#   and modifying MAKEFILE_DIR to THIS_MAKEFILE_DIR
+user_resource_bundle_sample:
+	$(MAKE) bundle-build bundle-publish bundle-register \
+	DIR="${THIS_MAKEFILE_DIR}templates/workspace_services/${WORKSPACE_SERVICE}/user_resources/${BUNDLE}" BUNDLE_TYPE=user_resource WORKSPACE_SERVICE_NAME=tre-service-${WORKSPACE_SERVICE}

--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,6 @@ SHELL:=/bin/bash
 
 AZURETRE_HOME?="AzureTRE"
 
-# This must come before the include statement
-# Otherwise, $(lastword) will be the last included file
-THIS_MAKEFILE_FULLPATH := $(abspath $(lastword $(MAKEFILE_LIST)))
-THIS_MAKEFILE_DIR := $(dir $(THIS_MAKEFILE_FULLPATH))
-
 include $(AZURETRE_HOME)/Makefile
 
 # Add your make commands down here
-
-# This is a sample make command to build user resource templates that are in this repo, versus the AzureTRE core repo
-# Any "make bundle" command from the AzureTRE core repo can be pasted here by modifying the command name
-#   and modifying MAKEFILE_DIR to THIS_MAKEFILE_DIR
-user_resource_bundle_sample:
-	$(MAKE) bundle-build bundle-publish bundle-register \
-	DIR="${THIS_MAKEFILE_DIR}templates/workspace_services/${WORKSPACE_SERVICE}/user_resources/${BUNDLE}" BUNDLE_TYPE=user_resource WORKSPACE_SERVICE_NAME=tre-service-${WORKSPACE_SERVICE}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 <!-- BEGIN MICROSOFT SECURITY.MD V0.0.7 BLOCK -->
 
-## Security
+# Security
 
 Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
 
@@ -14,17 +14,17 @@ Instead, please report them to the Microsoft Security Response Center (MSRC) at 
 
 If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/opensource/security/pgpkey).
 
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://aka.ms/opensource/security/msrc). 
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://aka.ms/opensource/security/msrc).
 
 Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
 
-  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
-  * Full paths of source file(s) related to the manifestation of the issue
-  * The location of the affected source code (tag/branch/commit or direct URL)
-  * Any special configuration required to reproduce the issue
-  * Step-by-step instructions to reproduce the issue
-  * Proof-of-concept or exploit code (if possible)
-  * Impact of the issue, including how an attacker might exploit the issue
+* Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+* Full paths of source file(s) related to the manifestation of the issue
+* The location of the affected source code (tag/branch/commit or direct URL)
+* Any special configuration required to reproduce the issue
+* Step-by-step instructions to reproduce the issue
+* Proof-of-concept or exploit code (if possible)
+* Impact of the issue, including how an attacker might exploit the issue
 
 This information will help us triage your report more quickly.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,25 +1,9 @@
-# TODO: The maintainer of this repo has not yet edited this file
-
-**REPO OWNER**: Do you want Customer Service & Support (CSS) support for this product/project?
-
-- **No CSS support:** Fill out this template with information about how to file issues and get help.
-- **Yes CSS support:** Fill out an intake form at [aka.ms/onboardsupport](https://aka.ms/onboardsupport). CSS will work with/help you to determine next steps.
-- **Not sure?** Fill out an intake as though the answer were "Yes". CSS will help you decide.
-
-*Then remove this first heading from this SUPPORT.MD file before publishing your repo.*
-
 # Support
 
 ## How to file issues and get help  
 
-This project uses GitHub Issues to track bugs and feature requests. Please search the existing 
-issues before filing new issues to avoid duplicates.  For new issues, file your bug or 
-feature request as a new Issue.
-
-For help and questions about using this project, please **REPO MAINTAINER: INSERT INSTRUCTIONS HERE 
-FOR HOW TO ENGAGE REPO OWNERS OR COMMUNITY FOR HELP. COULD BE A STACK OVERFLOW TAG OR OTHER
-CHANNEL. WHERE WILL YOU HELP PEOPLE?**.
+This project uses GitHub Issues to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates.  For new issues, file your bug or feature request as a new Issue.
 
 ## Microsoft Support Policy  
 
-Support for this **PROJECT or PRODUCT** is limited to the resources listed above.
+Support for this repo is limited to the resources listed above.


### PR DESCRIPTION
# Resolves #79

## What is being addressed

Markdown files in this repo have boilerplate text and don't follow Markdown linter suggestions.

## How is this addressed

Remove boilerplate from SUPPORT.md
Markdown linting of SECURITY.md