### PR TITLE
Parameterise the Azure TRE OSS repository location to allow easier repointing to fork

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -98,8 +98,9 @@ ARG OSS_VERSION
 ENV AZURETRE_HOME=/home/$USERNAME/AzureTRE
 COPY .devcontainer/scripts/install-azure-tre-oss.sh .devcontainer/devcontainer.json /tmp/
 # hadolint ignore=DL3004
-RUN oss_version_in_json=$(grep -oP '(?<="OSS_VERSION": ")[^"]*' /tmp/devcontainer.json) \
-    && /tmp/install-azure-tre-oss.sh "${OSS_VERSION:-$oss_version_in_json}" "${AZURETRE_HOME}" \
+RUN oss_repo_in_json=$(grep -oP '(?<="OSS_REPO": ")[^"]*' /tmp/devcontainer.json) \
+    && oss_version_in_json=$(grep -oP '(?<="OSS_VERSION": ")[^"]*' /tmp/devcontainer.json) \
+    && /tmp/install-azure-tre-oss.sh "${OSS_REPO:-$oss_repo_in_json}" "${OSS_VERSION:-$oss_version_in_json}" "${AZURETRE_HOME}"  \
     && sudo chown -R $USERNAME ${AZURETRE_HOME}
 
 # Install tre-cli

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,7 @@
       // 		export DOCKER_GROUP_ID=$(getent group docker | awk -F ":" '{ print $3 }')
       "DOCKER_GROUP_ID": "${localEnv:DOCKER_GROUP_ID}",
       "INTERACTIVE": "true",
+      "OSS_REPO": "microsoft/AzureTRE",
       "OSS_VERSION": "v0.15.2"
     }
   },

--- a/.devcontainer/scripts/install-azure-tre-oss.sh
+++ b/.devcontainer/scripts/install-azure-tre-oss.sh
@@ -5,14 +5,17 @@ set -o nounset
 # Uncomment this line to see each command for debugging (careful: this will show secrets!)
 # set -o xtrace
 
-oss_version="$1"
-oss_home="$2"
+
+oss_repo="$1"
+oss_version="$2"
+oss_home="$3"
 archive=/tmp/AzureTRE.tar.gz
 
-wget -O "$archive" "http://github.com/microsoft/AzureTRE/archive/${oss_version}.tar.gz" --progress=dot:giga
+wget -O "$archive" "http://github.com/${oss_repo}/archive/${oss_version}.tar.gz" --progress=dot:giga
 
 mkdir -p "$oss_home"
 tar -xzf "$archive" -C "$oss_home" --strip-components=1
 rm "$archive"
 
+echo "${oss_repo}" > "$oss_home/repository.txt"
 echo "${oss_version}" > "$oss_home/version.txt"


### PR DESCRIPTION
# Resolves #93 

## What is being addressed

Parameterises the AzureTRE GitHub repository URL fragment (e.g. `microsoft/AzureTRE`), and surfaces adjacent to existing `OSS_VERSION` argument (to set the version tag) to allow easier repointing when working in forked repos.

## How is this addressed

- Adds a new `OSS_REPO` parameter to `devcontainer.json` adjacent to the existing `OSS_VERSION` parameter
- Follows the same pattern as already used by `OSS_VERSION` to pass the variable through to the `install-azure-tre-oss.sh` script
- Applies the `OSS_REPO` variable to the `wget` command URL
- Creates a `repository.txt` file containing the `OSS_REPO` value alongside the existing `version.txt` file
