### PR TITLE
Upgrade Porter version in Dockerfile & add missing ARG

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -49,7 +49,7 @@ RUN if [ "${INTERACTIVE}" = "true" ]; then \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/* ; fi
 
 ARG PORTER_HOME_V1=/home/$USERNAME/.porter/
-ARG PORTER_VERSION=v1.0.11
+ARG PORTER_VERSION=v1.0.15
 ARG PORTER_TERRAFORM_MIXIN_VERSION=v1.0.2
 ARG PORTER_AZ_MIXIN_VERSION=v1.0.1
 ARG PORTER_AZURE_PLUGIN_VERSION=v1.2.0
@@ -94,6 +94,7 @@ COPY ./.devcontainer/scripts/gh.sh /tmp/
 RUN if [ "${INTERACTIVE}" = "true" ]; then /tmp/gh.sh; fi
 
 # Install AzureTRE OSS
+ARG OSS_REPO
 ARG OSS_VERSION
 ENV AZURETRE_HOME=/home/$USERNAME/AzureTRE
 COPY .devcontainer/scripts/install-azure-tre-oss.sh .devcontainer/devcontainer.json /tmp/


### PR DESCRIPTION
# Resolves #98

## What is being addressed

- Upgrade Dockerfile Porter version to align with microsoft/AzureTRE repo
- Fix missing ARG OSS_REPO variable in Dockerfile, it does works without it being declared, however should be explictly declared like ARG OSS_VERSION
