### PR TITLE
Make help returns commands both from the deployment repo and AzureTRE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,11 @@ AZURETRE_HOME?="AzureTRE"
 include $(AZURETRE_HOME)/Makefile
 
 # Get all the help messages from the AzureTRE origin Makefile and the current Makefile
-help: ## 💬 This help message :)
-	@grep -E '[a-zA-Z_-]+:.*?## .*$$' Makefile | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
+help: ## 💬 Custom help command that displays both the repository-specific and AzureTRE help for existing make commands.
+	@grep -E '^[^#][a-zA-Z_-]+:.*?## .*$$' Makefile | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
 	@echo "AzureTRE Makefile Commands"
-	@grep -E '[a-zA-Z_-]+:.*?## .*$$' $(firstword $(AZURETRE_HOME)/Makefile) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[^#][a-zA-Z_-]+:.*?## .*$$' $(firstword $(AZURETRE_HOME)/Makefile) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
 
 # Add your make commands down here
-
-# sample_command: ## Replace this description if you want it to be visible inside the help command
-# 	@echo "This is a sample command"
+sample_command: ## Replace this description with a meaningful one
+	@echo "This is a sample command"

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,13 @@ AZURETRE_HOME?="AzureTRE"
 
 include $(AZURETRE_HOME)/Makefile
 
+# Get all the help messages from the AzureTRE origin Makefile and the current Makefile
+help: ## 💬 This help message :)
+	@grep -E '[a-zA-Z_-]+:.*?## .*$$' Makefile | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
+	@echo "AzureTRE Makefile Commands"
+	@grep -E '[a-zA-Z_-]+:.*?## .*$$' $(firstword $(AZURETRE_HOME)/Makefile) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
+
 # Add your make commands down here
+
+# sample_command: ## Replace this description if you want it to be visible inside the help command
+# 	@echo "This is a sample command"


### PR DESCRIPTION
# Resolves HASH_SIGN_FOLLOWED_BY_ISSUE_NUMBER

## What is being addressed

The Makefile includes a custom help command that displays both the repository-specific and AzureTRE help for existing make commands.


## How is this addressed

- Added an override for a help command in the Makefile 
- The help command now displays help messages from both the current Makefile and the AzureTRE Makefile.
- Added a sample command sample_command as a placeholder for future commands.

## How to test
Run make help to see the combined help messages from both Makefiles.
Run make sample_command to see the sample command output.
