### PR TITLE
Validate storage account name in Register TRE Bundle

### DIFF
--- a/.github/workflows/register_tre_bundle.yml
+++ b/.github/workflows/register_tre_bundle.yml
@@ -80,6 +80,9 @@ jobs:
           if [ "${{ secrets.MGMT_STORAGE_ACCOUNT_NAME }}" == '' ]; then
             echo "Missing secret: MGMT_STORAGE_ACCOUNT_NAME" && exit 1
           fi
+          if ! [[ "${{ secrets.MGMT_STORAGE_ACCOUNT_NAME }}" =~ ^[a-z0-9]{3,24}$ ]]; then
+            echo "Invalid secret: MGMT_STORAGE_ACCOUNT_NAME must be between 3 and 24 characters and only lowercase letters (a–z) and numbers (0–9)" && exit 1
+          fi
           if [ "${{ secrets.TRE_ID }}" == '' ]; then
             echo "Missing secret: TRE_ID" && exit 1
           fi


### PR DESCRIPTION
# Improvement

## What is being addressed

Allow CI workflows to fail early via the "Register TRE Bundle" workflow is the Azure storage account name does not conform to the conventions that Azure expects

## How is this addressed

Add validation into the "Check required values" stage of the "Register TRE Bundle" workflow to provide early warning if the chosen storage account name doesn't conform to the format that Azure allows.
